### PR TITLE
self: Led.get and Led.set should not move Led

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ use aorura::*;
 use failure::*;
 
 fn main() -> Fallible<()> {
-  let led = Led::open("/dev/ttyUSB0")?;
+  let mut led = Led::open("/dev/ttyUSB0")?;
 
   led.set(State::Flash(Color::Red))?; // cause LED to flash with red color
   led.set(State::Off)?; // turn off LED

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Fallible<()> {
         .deserialize()
         .unwrap_or_else(|e| e.exit());
 
-    let led = Led::open(args.arg_path)?;
+    let mut led = Led::open(args.arg_path)?;
     let state = match args.flag_set {
         Some(state) => {
             led.set(state)?;

--- a/self/src/lib.rs
+++ b/self/src/lib.rs
@@ -77,7 +77,7 @@ impl Led {
     }
 
     /// Get AORURA LED state.
-    pub fn get(mut self) -> Fallible<State> {
+    pub fn get(&mut self) -> Fallible<State> {
         let mut cmd = [0u8; 2];
 
         self.0.write(&STATUS_COMMAND)?;
@@ -87,7 +87,7 @@ impl Led {
     }
 
     /// Set AORURA LED to given state.
-    pub fn set(mut self, state: State) -> Fallible<()> {
+    pub fn set(&mut self, state: State) -> Fallible<()> {
         let cmd: Command = state.into();
         let mut output = [0u8; 1];
 


### PR DESCRIPTION
Before this change it was impossible to use `Led` more than one time.

```
error[E0382]: use of moved value: `led`
  --> src/main.rs:64:9
   |
55 |     let led = Led::open(args.arg_path)?;
   |         --- move occurs because `led` has type `aorura::Led`, which does not implement the `Copy` trait
...
64 |         led.set(state)?;
   |         ^^^ value moved here, in previous iteration of loop
```