### PR TITLE
Reword README and headline

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 repository:
   name: aorura
-  description: AORURA LED library, state manager CLI, and emulator
+  description: AORURA library, LED manager CLI, and emulator
   topics: led
   private: false
   has_issues: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AORURA
 
-AORURA LED library, state manager CLI, and emulator.
+AORURA library, LED manager CLI, and emulator.
 
 ## Protocol
 
@@ -52,7 +52,7 @@ fn main() -> Fallible<()> {
 
 ## CLI
 
-[`aorura-cli`](cli) is a state manager CLI built on top of [`aorura`](#library).
+[`aorura-cli`](cli) is LED manager CLI built on top of [`aorura`](#library).
 
 ```
 Usage: aorura-cli <path> [--set STATE]


### PR DESCRIPTION
- Use AORURA instead of AORURA LED when referring to device
- Use "LED manager" not "state manager" when referring to CLI