### PR TITLE
emu: refactor info library + CLI

### DIFF
--- a/emu/src/lib.rs
+++ b/emu/src/lib.rs
@@ -1,0 +1,5 @@
+mod pty;
+mod server;
+
+pub use pty::Pty;
+pub use server::Server;

--- a/emu/src/main.rs
+++ b/emu/src/main.rs
@@ -1,18 +1,9 @@
-use aorura::*;
+use aorura_emu::{Pty, Server};
 use docopt::Docopt;
 use failure::*;
 use serde::*;
 
-use nix::fcntl::{self, OFlag};
-use nix::pty::*;
-use nix::sys::stat::Mode;
-
-use std::convert::TryFrom;
 use std::env;
-use std::fs::{remove_file, File};
-use std::io::prelude::*;
-use std::os::unix::fs::symlink;
-use std::os::unix::io::*;
 use std::path::PathBuf;
 
 const USAGE: &'static str = "
@@ -27,30 +18,6 @@ struct Args {
     arg_path: PathBuf,
 }
 
-struct Pty {
-    master_fd: PtyMaster,
-    slave_fd: RawFd,
-    slave_path: PathBuf,
-}
-
-impl Pty {
-    fn open() -> Fallible<Self> {
-        let master_fd = posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY)?;
-
-        grantpt(&master_fd)?;
-        unlockpt(&master_fd)?;
-
-        let slave_path = PathBuf::from(unsafe { ptsname(&master_fd) }?);
-        let slave_fd = fcntl::open(&slave_path, OFlag::O_RDWR, Mode::empty())?;
-
-        Ok(Pty {
-            master_fd,
-            slave_fd,
-            slave_path,
-        })
-    }
-}
-
 fn main() -> Fallible<()> {
     env_logger::init();
 
@@ -59,32 +26,6 @@ fn main() -> Fallible<()> {
         .deserialize()
         .unwrap_or_else(|e| e.exit());
 
-    let mut state = State::Flash(Color::Blue);
-
-    let pty = Pty::open()?;
-    let _ = remove_file(&args.arg_path);
-    symlink(&pty.slave_path, &args.arg_path)?;
-
-    let mut f = unsafe { File::from_raw_fd(pty.master_fd.clone().into_raw_fd()) };
-    let mut cmd: Command = [0u8; 2];
-
-    loop {
-        f.read_exact(&mut cmd)?;
-
-        if cmd == STATUS_COMMAND {
-            cmd = state.into();
-            f.write(&cmd)?;
-        } else {
-            match State::try_from(&cmd) {
-                Ok(new_state) => {
-                    state = new_state;
-                    f.write(b"Y")?;
-                }
-                Err(err) => {
-                    log::warn!("{}", err);
-                    f.write(b"N")?;
-                }
-            }
-        }
-    }
+    let mut pty = Pty::open(args.arg_path)?;
+    Server::new().run(&mut pty.master, true)
 }

--- a/emu/src/pty.rs
+++ b/emu/src/pty.rs
@@ -1,0 +1,43 @@
+use failure::*;
+
+use nix::fcntl::{self, OFlag};
+use nix::pty::*;
+use nix::sys::stat::Mode;
+
+use std::fs::{remove_file, File};
+use std::os::unix::fs::symlink;
+use std::os::unix::io::*;
+use std::path::{Path, PathBuf};
+
+pub struct Pty {
+    pub master: File,
+    pub slave: File,
+    target_path: PathBuf,
+}
+
+impl Pty {
+    pub fn open<P: AsRef<Path>>(target: P) -> Fallible<Self> {
+        let master_fd = posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY)?;
+
+        grantpt(&master_fd)?;
+        unlockpt(&master_fd)?;
+
+        let slave_path = PathBuf::from(unsafe { ptsname(&master_fd) }?);
+        let slave_fd = fcntl::open(&slave_path, OFlag::O_RDWR, Mode::empty())?;
+
+        let target_path = target.as_ref();
+        symlink(&slave_path, &target_path)?;
+
+        Ok(Pty {
+            master: unsafe { File::from_raw_fd(master_fd.into_raw_fd()) },
+            slave: unsafe { File::from_raw_fd(slave_fd) },
+            target_path: target_path.to_path_buf(),
+        })
+    }
+}
+
+impl Drop for Pty {
+    fn drop(&mut self) {
+        let _ = remove_file(&self.target_path);
+    }
+}

--- a/emu/src/server.rs
+++ b/emu/src/server.rs
@@ -1,0 +1,54 @@
+use aorura::*;
+use failure::*;
+
+use std::convert::TryFrom;
+use std::io::prelude::*;
+use std::sync::Mutex;
+
+pub struct Server {
+    state: Mutex<State>,
+}
+
+impl Server {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(Default::default()),
+        }
+    }
+
+    pub fn get(&self) -> State {
+        *self.state.lock().unwrap()
+    }
+
+    pub fn run<RW: Read + Write>(&self, master: &mut RW, is_writable: bool) -> Fallible<()> {
+        let mut cmd: Command = Default::default();
+
+        loop {
+            master.read_exact(&mut cmd)?;
+
+            let mut state = self.state.lock().unwrap();
+
+            if cmd == STATUS_COMMAND {
+                cmd = (*state).into();
+                master.write(&cmd)?;
+            } else {
+                match State::try_from(&cmd) {
+                    Ok(new_state) => {
+                        if is_writable {
+                            *state = new_state;
+                        }
+                        master.write(b"Y")?;
+                    }
+                    Err(err) => {
+                        log::warn!("{}", err);
+                        master.write(b"N")?;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn set(&self, state: State) -> () {
+        *self.state.lock().unwrap() = state
+    }
+}

--- a/self/src/lib.rs
+++ b/self/src/lib.rs
@@ -40,6 +40,10 @@ pub type Command = [u8; 2];
 
 pub const STATUS_COMMAND: Command = [b'S', b'S'];
 
+impl Default for State {
+    fn default() -> Self { State::Flash(Color::Blue) }
+}
+
 impl Into<Command> for State {
     fn into(self) -> Command {
         match self {


### PR DESCRIPTION
This implements and exposes `aorura_emu::Pty` and `aorura_emu::Server`. This is now way more generic. `Pty` isn't specific to AORURA at all, while `Server` can work over any `Read + Write`, not just `Pty`. `Server` can even be used verbatim to implement AORURA firmware.

Documentation isn't included just yet. I want to move `Server` into `core`, and `Pty` into a separate reusable crate first.